### PR TITLE
Ref indexes apply dry issues7and8

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ You can download FASTA files from the [Ensembl](https://asia.ensembl.org/info/da
 This pipeline uses the following tools for generating specific index files.
   - [samtools](https://www.htslib.org/doc/samtools-faidx.html).fai
   - [picard](https://gatk.broadinstitute.org/hc/en-us/articles/360037593331-CreateSequenceDictionary-Picard-).dict 
-  - [bwa](https://bio-bwa.sourceforge.net/bwa.shtml).amb, .ann, .bwt, .pac, .sa 
 
 When you run the pipeline, you will use the mandatory `--ref` and `--dict` parameters to specify the location and names of the reference files:
 ```

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -11,92 +11,64 @@ singularity {
 }
 
 process {
-module = 'singularity'
+    module = 'singularity'
     cache = 'lenient'
     stageInMode = 'symlink'
     project = "${params.gadi_account}"
     storage = "scratch/${params.gadi_account}+gdata/${params.gadi_account}"
-        
+    executor = 'pbspro'
+    queue = 'normal'    
+    cpus = 1
+    time = '1h'
+    memory = '20.GB'
+
 
 withName: 'checkInputs' {
 	executor = 'local'
+	memory = '4.GB'
 }
-withName: '' {
-	executor = 'local'
-}
+
 
 
 withName: 'mutect2' {
-        executor = 'pbspro'
         queue = 'normal'
-        cpus = 8
+        cpus = 1
         time = '6h'
         memory = '80.GB'
 }
 
 withName: 'GatherVcfs' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 withName: 'MergeMutectStats' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 withName: 'LearnReadOrientationModel' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
+
 withName: 'GetPileupSummaries_T' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 withName: 'GetPileupSummaries_N' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 
 withName: 'CalculateContamination' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 withName: 'FilterMutectCalls' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 withName: 'getFilteredVariants' {
-        executor = 'pbspro'
-        queue = 'normal'
-        cpus = 8
-        time = '6h'
-        memory = '80.GB'
+	cpus = 1
 }
 
 

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -31,45 +31,22 @@ withName: 'checkInputs' {
 
 
 withName: 'mutect2' {
-        queue = 'normal'
-        cpus = 1
         time = '6h'
-        memory = '80.GB'
+        memory = '60.GB'
 }
 
 withName: 'GatherVcfs' {
-	cpus = 1
+	memory = '60.GB'
 }
 
 withName: 'MergeMutectStats' {
-	cpus = 1
-}
-
-withName: 'LearnReadOrientationModel' {
-	cpus = 1
-}
-
-
-withName: 'GetPileupSummaries_T' {
-	cpus = 1
-}
-
-withName: 'GetPileupSummaries_N' {
-	cpus = 1
-}
-
-
-withName: 'CalculateContamination' {
-	cpus = 1
-}
-
-withName: 'FilterMutectCalls' {
-	cpus = 1
-}
+        memory = '60.GB'
+        }
 
 withName: 'getFilteredVariants' {
-	cpus = 1
-}
+        memory = '60.GB'
+        }
+
 
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,52 +47,46 @@ shell = ['/bin/bash', '-euo', 'pipefail']
 // default run resource parameters
 process {
   container = 'quay.io/biocontainers/gatk4:4.4.0.0--py36hdfd78af_0'
+  cpus = 1
+  memory = '20.GB'
 
 withName: 'mutect2' {
-        cpus = 8
+        cpus = 1
         memory = '80.GB'
     }
 
     withName: 'GatherVcfs' {
-        cpus = 8
-        memory = '80.GB'   
+	cpus = 1
         }
  
 
     withName: 'MergeMutectStats' {
-        cpus = 8
-        memory = '80.GB'
+	cpus = 1
         } 
 
     withName: 'LearnReadOrientationModel' {
-        cpus = 8
-        memory = '80.GB'
+	cpus = 1
         } 
 
   withName: 'GetPileupSummaries_T' {
-        cpus = 8
-        memory = '80.GB'  
+	cpus = 1
     } 
 
   withName: 'GetPileupSummaries_N' {
-        cpus = 8
-        memory = '80.GB' 
+	cpus = 1
     } 
 
   withName: 'CalculateContamination' {
-        cpus = 8
-        memory = '80.GB'
+	cpus = 1
     } 
 
   withName: 'FilterMutectCalls' {
-        cpus = 8
-        memory = '80.GB'
+	cpus = 1
     } 
 
 withName: 'getFilteredVariants' {
-        cpus = 8
-        memory = '80.GB' 
-} 
+	cpus = 1
+    } 
 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,42 +51,21 @@ process {
   memory = '20.GB'
 
 withName: 'mutect2' {
-        cpus = 1
-        memory = '80.GB'
+        memory = '60.GB'
     }
 
-    withName: 'GatherVcfs' {
-	cpus = 1
-        }
+withName: 'GatherVcfs' {
+        memory = '60.GB'
+	}
  
 
-    withName: 'MergeMutectStats' {
-	cpus = 1
+withName: 'MergeMutectStats' {
+	memory = '60.GB'
         } 
-
-    withName: 'LearnReadOrientationModel' {
-	cpus = 1
-        } 
-
-  withName: 'GetPileupSummaries_T' {
-	cpus = 1
-    } 
-
-  withName: 'GetPileupSummaries_N' {
-	cpus = 1
-    } 
-
-  withName: 'CalculateContamination' {
-	cpus = 1
-    } 
-
-  withName: 'FilterMutectCalls' {
-	cpus = 1
-    } 
 
 withName: 'getFilteredVariants' {
-	cpus = 1
-    } 
+    	memory = '60.GB'
+	} 
 
 }
 

--- a/run_pipeline_on_gadi_script.sh
+++ b/run_pipeline_on_gadi_script.sh
@@ -20,8 +20,8 @@ module load singularity
 export NXF_SINGULARITY_CACHEDIR=/scratch/$PROJECT/$(whoami)/singularity
 
 # Fill in these variables for your run
-#samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-83-Somatic-ShortV/test_files_for_Georgie/samples.csv
-samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-83-Somatic-ShortV/test_files_for_Georgie/samples_full.csv
+samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-83-Somatic-ShortV/test_files_for_Georgie/samples.csv
+#samples=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-83-Somatic-ShortV/test_files_for_Georgie/samples_full.csv
 ponvcf=/scratch/er01/ndes8648/pipeline_work/nextflow/INFRA-83-Somatic-ShortV/test_files_for_Georgie/pon.vcf.gz
 ref=/g/data/er01/SIH-HPC-WGS/Reference/hs38DH.fasta
 common_biallelic_variants=/g/data/er01/SIH-HPC-WGS/Reference/gatk-best-practices/somatic-hg38/small_exac_common_3.hg38.vcf.gz
@@ -31,7 +31,7 @@ dict=/g/data/er01/SIH-HPC-WGS/Reference/hs38DH.dict
 
 
 # Run the pipeline 
-nextflow run main.nf \
+nextflow run main.nf -resume \
         --input ${samples} \
         -profile gadi \
         --whoami $(whoami) --gadi_account $PROJECT \


### PR DESCRIPTION
#7 
Checked the documentations and also tested the pipeline by isolating the indices
Only the following reference files are used by gatk
Ref.fasta
Ref.fai and
Ref.dict

#8 

- The nextflow.config and config/gadi.config files are now updated as per DRY requirements.
- None of the modules for Somatic variant calling use native multithreading (mutect2 uses scatter-garther).
- I have included higher memory requirements for specific modules such as mutect and others in the config file. The higher memory is estimated based on the couple of runs peformed for FULL bam files.



